### PR TITLE
Fixed FontAwesome converter for UWP

### DIFF
--- a/src/FontAwesome.UWP.Demo/FontAwesome.UWP.Demo.csproj
+++ b/src/FontAwesome.UWP.Demo/FontAwesome.UWP.Demo.csproj
@@ -104,7 +104,6 @@
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
-    <None Include="FontAwesome.UWP.Demo_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Properties\Default.rd.xml" />

--- a/src/FontAwesome.UWP.Lib/FontAwesome.UWP.Lib.csproj
+++ b/src/FontAwesome.UWP.Lib/FontAwesome.UWP.Lib.csproj
@@ -104,9 +104,9 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
-    <Resource Include="..\..\Font-Awesome\fonts\FontAwesome.otf">
+    <Content Include="..\..\Font-Awesome\fonts\FontAwesome.otf">
       <Link>FontAwesome.otf</Link>
-    </Resource>
+    </Content>
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FontAwesome.UWP.Lib/FontAwesome.cs
+++ b/src/FontAwesome.UWP.Lib/FontAwesome.cs
@@ -7,7 +7,7 @@ namespace FontAwesome.UWP.Lib
     {
         public FontAwesome()
         {
-            this.FontFamily = new FontFamily("./fontawesome.otf#FontAwesome");
+            this.FontFamily = new FontFamily("ms-appx:///FontAwesome.UWP.Lib/fontawesome.otf#FontAwesome");
         }
 
         private FontAwesomeIcon _icon;


### PR DESCRIPTION
Hi Robert, 
changed integration Type from resource to content. Sot the FontAwesome.otf is part of the AppX Packaged. 

After this changed the path in you converter to reference the file inside the appx-package. 

Works for me. 